### PR TITLE
New and updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The goal of trajtools is to provide a place for people to discover,
 explore, test and use open source tools for working with trajectory
 data.
 
-There are many existing tools for work with trajectories, writting in
+There are [many existing tools](https://github.com/anitagraser/movement-analysis-tools) for work with trajectories, writting in
 various languages/frameworks, including the R packages
 [trip](https://github.com/Trackage/trip), the Python package
-[movingpandas](https://github.com/anitagraser/movingpandas) and the QGIS
+[movingpandas](https://github.com/movingpandas/movingpandas) and the QGIS
 Plugin
-[trajectools](https://github.com/anitagraser/qgis-processing-trajectory).
+[trajectools](https://github.com/movingpandas/qgis-processing-trajectory).
 However, there little in the way of cross-comparison, feature
 comparison, or documentation that bridges the divide between different
 trajectory packages, let alone languages.


### PR DESCRIPTION
MovingPandas and Trajectools have moved to the MovingPandas Github organization. 

In https://github.com/anitagraser/movement-analysis-tools/releases/tag/giforum2022 you can find a comparison of visualization capabilities. 

Martin et al. [0] also provide some comparison. 

[0] Martin, H., Hong, Y., Wiedemann, N., Bucher, D., & Raubal, M. (2023). [Trackintel: An open-source Python library for human mobility analysis](https://doi.org/10.1016/j.compenvurbsys.2023.101938). Computers, Environment and Urban Systems, 101, 101938.